### PR TITLE
Speed up table lookups if using newer compiler (#27)

### DIFF
--- a/routectrl3/flashmem.h
+++ b/routectrl3/flashmem.h
@@ -12,7 +12,12 @@
 
 #ifdef __AVR_HAVE_ELPMX__
 // AVR supports ELPM with Z+ so tables may be located above 64KB. Use 24-bit pointer
+#if __GNUC__ >= 15
+// avr-gcc supports __flashx from version 15
+#define FLASHMEM __flashx
+#else
 #define FLASHMEM __memx
+#endif
 #else
 // AVR doesn't support data in flash above 64KB. Use normal 16-bit pointer
 #define FLASHMEM __flash

--- a/routectrl3/route.h
+++ b/routectrl3/route.h
@@ -53,7 +53,7 @@ typedef struct
 #define ROUTE(num, act, fre, can, ...) \
 static const FLASHMEM uint16_t routecstrs##num[] = { __VA_ARGS__ }; \
 static const route_table_t routeentry##num \
-__attribute__((used, section("loconet.routetable"))) = { \
+__attribute__((used, section("loconet.routetable." #num))) = { \
     .routenum = num, \
     .constraint_cnt = sizeof(routecstrs##num) / sizeof(routecstrs##num[0]), \
     .constraint = routecstrs##num, \

--- a/routectrl3/routectrl3.componentinfo.xml
+++ b/routectrl3/routectrl3.componentinfo.xml
@@ -9,13 +9,13 @@
 			<CSub></CSub>
 			<CVariant></CVariant>
 			<CVendor>Atmel</CVendor>
-			<CVersion>2.6.0</CVersion>
+			<CVersion>2.7.0</CVersion>
 			<DefaultRepoPath>C:/Program Files (x86)\Atmel\Studio\7.0\Packs</DefaultRepoPath>
 			<DependentComponents xmlns:d4p1="http://schemas.microsoft.com/2003/10/Serialization/Arrays" />
 			<Description></Description>
 			<Files xmlns:d4p1="http://schemas.microsoft.com/2003/10/Serialization/Arrays">
 				<d4p1:anyType i:type="FileInfo">
-					<AbsolutePath>C:/Program Files (x86)\Atmel\Studio\7.0\Packs\Atmel\AVR-Dx_DFP\2.6.303\include\</AbsolutePath>
+					<AbsolutePath>C:/Program Files (x86)\Atmel\Studio\7.0\Packs\Atmel\AVR-Dx_DFP\2.7.321\include\</AbsolutePath>
 					<Attribute></Attribute>
 					<Category>include</Category>
 					<Condition>C</Condition>
@@ -26,18 +26,18 @@
 					<SourcePath></SourcePath>
 				</d4p1:anyType>
 				<d4p1:anyType i:type="FileInfo">
-					<AbsolutePath>C:/Program Files (x86)\Atmel\Studio\7.0\Packs\Atmel\AVR-Dx_DFP\2.6.303\include\avr\ioavr128da48.h</AbsolutePath>
+					<AbsolutePath>C:/Program Files (x86)\Atmel\Studio\7.0\Packs\Atmel\AVR-Dx_DFP\2.7.321\include\avr\ioavr128da48.h</AbsolutePath>
 					<Attribute></Attribute>
 					<Category>header</Category>
 					<Condition>C</Condition>
-					<FileContentHash>EycDfYGxRAG13YO+Eia91Q==</FileContentHash>
+					<FileContentHash>0XJJlWOO3CBVyJMcS8KBJw==</FileContentHash>
 					<FileVersion></FileVersion>
 					<Name>include/avr/ioavr128da48.h</Name>
 					<SelectString></SelectString>
 					<SourcePath></SourcePath>
 				</d4p1:anyType>
 				<d4p1:anyType i:type="FileInfo">
-					<AbsolutePath>C:/Program Files (x86)\Atmel\Studio\7.0\Packs\Atmel\AVR-Dx_DFP\2.6.303\templates\main.c</AbsolutePath>
+					<AbsolutePath>C:/Program Files (x86)\Atmel\Studio\7.0\Packs\Atmel\AVR-Dx_DFP\2.7.321\templates\main.c</AbsolutePath>
 					<Attribute>template</Attribute>
 					<Category>source</Category>
 					<Condition>C Exe</Condition>
@@ -48,7 +48,7 @@
 					<SourcePath></SourcePath>
 				</d4p1:anyType>
 				<d4p1:anyType i:type="FileInfo">
-					<AbsolutePath>C:/Program Files (x86)\Atmel\Studio\7.0\Packs\Atmel\AVR-Dx_DFP\2.6.303\templates\main.cpp</AbsolutePath>
+					<AbsolutePath>C:/Program Files (x86)\Atmel\Studio\7.0\Packs\Atmel\AVR-Dx_DFP\2.7.321\templates\main.cpp</AbsolutePath>
 					<Attribute>template</Attribute>
 					<Category>source</Category>
 					<Condition>C Exe</Condition>
@@ -59,7 +59,7 @@
 					<SourcePath></SourcePath>
 				</d4p1:anyType>
 				<d4p1:anyType i:type="FileInfo">
-					<AbsolutePath>C:/Program Files (x86)\Atmel\Studio\7.0\Packs\Atmel\AVR-Dx_DFP\2.6.303\gcc\dev\avr128da48</AbsolutePath>
+					<AbsolutePath>C:/Program Files (x86)\Atmel\Studio\7.0\Packs\Atmel\AVR-Dx_DFP\2.7.321\gcc\dev\avr128da48</AbsolutePath>
 					<Attribute></Attribute>
 					<Category>libraryPrefix</Category>
 					<Condition>GCC</Condition>
@@ -71,8 +71,8 @@
 				</d4p1:anyType>
 			</Files>
 			<PackName>AVR-Dx_DFP</PackName>
-			<PackPath>C:/Program Files (x86)/Atmel/Studio/7.0/Packs/Atmel/AVR-Dx_DFP/2.6.303/Atmel.AVR-Dx_DFP.pdsc</PackPath>
-			<PackVersion>2.6.303</PackVersion>
+			<PackPath>C:/Program Files (x86)/Atmel/Studio/7.0/Packs/Atmel/AVR-Dx_DFP/2.7.321/Atmel.AVR-Dx_DFP.pdsc</PackPath>
+			<PackVersion>2.7.321</PackVersion>
 			<PresentInProject>true</PresentInProject>
 			<ReferenceConditionId>AVR128DA48</ReferenceConditionId>
 			<RteComponents xmlns:d4p1="http://schemas.microsoft.com/2003/10/Serialization/Arrays">

--- a/routectrl3/routectrl3.cproj
+++ b/routectrl3/routectrl3.cproj
@@ -15,7 +15,7 @@
     <AssemblyName>demo</AssemblyName>
     <Name>demo</Name>
     <RootNamespace>demo</RootNamespace>
-    <ToolchainFlavour>Native</ToolchainFlavour>
+    <ToolchainFlavour>avr-gcc 15.1.0</ToolchainFlavour>
     <KeepTimersRunning>true</KeepTimersRunning>
     <OverrideVtor>false</OverrideVtor>
     <CacheFlash>true</CacheFlash>
@@ -48,96 +48,96 @@
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <ToolchainSettings>
       <AvrGcc>
-        <avrgcc.common.Device>-mmcu=avr128da48 -B "%24(PackRepoDir)\Atmel\AVR-Dx_DFP\2.6.303\gcc\dev\avr128da48"</avrgcc.common.Device>
-        <avrgcc.common.outputfiles.hex>True</avrgcc.common.outputfiles.hex>
-        <avrgcc.common.outputfiles.lss>True</avrgcc.common.outputfiles.lss>
-        <avrgcc.common.outputfiles.eep>True</avrgcc.common.outputfiles.eep>
-        <avrgcc.common.outputfiles.srec>False</avrgcc.common.outputfiles.srec>
-        <avrgcc.common.outputfiles.usersignatures>False</avrgcc.common.outputfiles.usersignatures>
-        <avrgcc.compiler.general.ChangeDefaultCharTypeUnsigned>True</avrgcc.compiler.general.ChangeDefaultCharTypeUnsigned>
-        <avrgcc.compiler.general.ChangeDefaultBitFieldUnsigned>True</avrgcc.compiler.general.ChangeDefaultBitFieldUnsigned>
-        <avrgcc.compiler.symbols.DefSymbols>
-          <ListValues>
-            <Value>F_CPU=24000000UL</Value>
-            <Value>LNPACKET_SIZE_MAX=6</Value>
-            <Value>LNPACKET_CNT=16</Value>
-            <Value>EXTXTAL</Value>
-            <Value>NDEBUG</Value>
-          </ListValues>
-        </avrgcc.compiler.symbols.DefSymbols>
-        <avrgcc.compiler.directories.IncludePaths>
-          <ListValues>
-            <Value>%24(ProjectDir)\lib\</Value>
-            <Value>%24(PackRepoDir)\Atmel\AVR-Dx_DFP\2.6.303\include\</Value>
-          </ListValues>
-        </avrgcc.compiler.directories.IncludePaths>
-        <avrgcc.compiler.optimization.PackStructureMembers>True</avrgcc.compiler.optimization.PackStructureMembers>
-        <avrgcc.compiler.optimization.AllocateBytesNeededForEnum>True</avrgcc.compiler.optimization.AllocateBytesNeededForEnum>
-        <avrgcc.compiler.warnings.AllWarnings>True</avrgcc.compiler.warnings.AllWarnings>
-        <avrgcc.compiler.warnings.WarningsAsErrors>True</avrgcc.compiler.warnings.WarningsAsErrors>
-        <avrgcc.linker.libraries.Libraries>
-          <ListValues>
-            <Value>libm</Value>
-          </ListValues>
-        </avrgcc.linker.libraries.Libraries>
-        <avrgcc.linker.miscellaneous.LinkerFlags>-T %24(ProjectDir)\routetables.ld -T %24(ProjectDir)\lib\avr-shell-cmd\cmdtables.ld</avrgcc.linker.miscellaneous.LinkerFlags>
-        <avrgcc.assembler.general.IncludePaths>
-          <ListValues>
-            <Value>%24(PackRepoDir)\Atmel\AVR-Dx_DFP\2.6.303\include\</Value>
-          </ListValues>
-        </avrgcc.assembler.general.IncludePaths>
-        <avrgcc.compiler.optimization.level>Optimize for size (-Os)</avrgcc.compiler.optimization.level>
-      </AvrGcc>
+  <avrgcc.common.Device>-mmcu=avr128da48 -B "%24(PackRepoDir)\Atmel\AVR-Dx_DFP\2.7.321\gcc\dev\avr128da48"</avrgcc.common.Device>
+  <avrgcc.common.outputfiles.hex>True</avrgcc.common.outputfiles.hex>
+  <avrgcc.common.outputfiles.lss>True</avrgcc.common.outputfiles.lss>
+  <avrgcc.common.outputfiles.eep>True</avrgcc.common.outputfiles.eep>
+  <avrgcc.common.outputfiles.srec>False</avrgcc.common.outputfiles.srec>
+  <avrgcc.common.outputfiles.usersignatures>False</avrgcc.common.outputfiles.usersignatures>
+  <avrgcc.compiler.general.ChangeDefaultCharTypeUnsigned>True</avrgcc.compiler.general.ChangeDefaultCharTypeUnsigned>
+  <avrgcc.compiler.general.ChangeDefaultBitFieldUnsigned>True</avrgcc.compiler.general.ChangeDefaultBitFieldUnsigned>
+  <avrgcc.compiler.symbols.DefSymbols>
+    <ListValues>
+      <Value>F_CPU=24000000UL</Value>
+      <Value>LNPACKET_SIZE_MAX=6</Value>
+      <Value>LNPACKET_CNT=16</Value>
+      <Value>EXTXTAL</Value>
+      <Value>NDEBUG</Value>
+    </ListValues>
+  </avrgcc.compiler.symbols.DefSymbols>
+  <avrgcc.compiler.directories.IncludePaths>
+    <ListValues>
+      <Value>%24(ProjectDir)\lib\</Value>
+      <Value>%24(PackRepoDir)\Atmel\AVR-Dx_DFP\2.7.321\include\</Value>
+    </ListValues>
+  </avrgcc.compiler.directories.IncludePaths>
+  <avrgcc.compiler.optimization.level>Optimize (-O1)</avrgcc.compiler.optimization.level>
+  <avrgcc.compiler.optimization.PackStructureMembers>True</avrgcc.compiler.optimization.PackStructureMembers>
+  <avrgcc.compiler.optimization.AllocateBytesNeededForEnum>True</avrgcc.compiler.optimization.AllocateBytesNeededForEnum>
+  <avrgcc.compiler.warnings.AllWarnings>True</avrgcc.compiler.warnings.AllWarnings>
+  <avrgcc.compiler.warnings.WarningsAsErrors>True</avrgcc.compiler.warnings.WarningsAsErrors>
+  <avrgcc.linker.libraries.Libraries>
+    <ListValues>
+      <Value>libm</Value>
+    </ListValues>
+  </avrgcc.linker.libraries.Libraries>
+  <avrgcc.linker.miscellaneous.LinkerFlags>-T %24(ProjectDir)\routetables.ld -T %24(ProjectDir)\lib\avr-shell-cmd\cmdtables.ld</avrgcc.linker.miscellaneous.LinkerFlags>
+  <avrgcc.assembler.general.IncludePaths>
+    <ListValues>
+      <Value>%24(PackRepoDir)\Atmel\AVR-Dx_DFP\2.7.321\include\</Value>
+    </ListValues>
+  </avrgcc.assembler.general.IncludePaths>
+</AvrGcc>
     </ToolchainSettings>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <ToolchainSettings>
       <AvrGcc>
-        <avrgcc.common.Device>-mmcu=avr128da48 -B "%24(PackRepoDir)\Atmel\AVR-Dx_DFP\2.6.303\gcc\dev\avr128da48"</avrgcc.common.Device>
-        <avrgcc.common.outputfiles.hex>True</avrgcc.common.outputfiles.hex>
-        <avrgcc.common.outputfiles.lss>True</avrgcc.common.outputfiles.lss>
-        <avrgcc.common.outputfiles.eep>True</avrgcc.common.outputfiles.eep>
-        <avrgcc.common.outputfiles.srec>False</avrgcc.common.outputfiles.srec>
-        <avrgcc.common.outputfiles.usersignatures>False</avrgcc.common.outputfiles.usersignatures>
-        <avrgcc.compiler.general.ChangeDefaultCharTypeUnsigned>True</avrgcc.compiler.general.ChangeDefaultCharTypeUnsigned>
-        <avrgcc.compiler.general.ChangeDefaultBitFieldUnsigned>True</avrgcc.compiler.general.ChangeDefaultBitFieldUnsigned>
-        <avrgcc.compiler.symbols.DefSymbols>
-          <ListValues>
-            <Value>F_CPU=24000000UL</Value>
-            <Value>LNPACKET_SIZE_MAX=6</Value>
-            <Value>LNPACKET_CNT=16</Value>
-            <Value>EXTXTAL</Value>
-            <Value>DEBUG</Value>
-            <Value>LNSTAT</Value>
-            <Value>ROUTE_DEBUG</Value>
-          </ListValues>
-        </avrgcc.compiler.symbols.DefSymbols>
-        <avrgcc.compiler.directories.IncludePaths>
-          <ListValues>
-            <Value>%24(ProjectDir)\lib\</Value>
-            <Value>%24(PackRepoDir)\Atmel\AVR-Dx_DFP\2.6.303\include\</Value>
-          </ListValues>
-        </avrgcc.compiler.directories.IncludePaths>
-        <avrgcc.compiler.optimization.PackStructureMembers>True</avrgcc.compiler.optimization.PackStructureMembers>
-        <avrgcc.compiler.optimization.AllocateBytesNeededForEnum>True</avrgcc.compiler.optimization.AllocateBytesNeededForEnum>
-        <avrgcc.compiler.optimization.DebugLevel>Default (-g2)</avrgcc.compiler.optimization.DebugLevel>
-        <avrgcc.compiler.warnings.AllWarnings>True</avrgcc.compiler.warnings.AllWarnings>
-        <avrgcc.compiler.warnings.WarningsAsErrors>True</avrgcc.compiler.warnings.WarningsAsErrors>
-        <avrgcc.linker.libraries.Libraries>
-          <ListValues>
-            <Value>libm</Value>
-          </ListValues>
-        </avrgcc.linker.libraries.Libraries>
-        <avrgcc.linker.miscellaneous.LinkerFlags>-T %24(ProjectDir)\routetables.ld -T %24(ProjectDir)\lib\avr-shell-cmd\cmdtables.ld</avrgcc.linker.miscellaneous.LinkerFlags>
-        <avrgcc.assembler.general.IncludePaths>
-          <ListValues>
-            <Value>%24(PackRepoDir)\Atmel\AVR-Dx_DFP\2.6.303\include\</Value>
-          </ListValues>
-        </avrgcc.assembler.general.IncludePaths>
-        <avrgcc.compiler.optimization.level>Optimize debugging experience (-Og)</avrgcc.compiler.optimization.level>
-        <avrgcc.compiler.optimization.DebugLevel>Default (-g2)</avrgcc.compiler.optimization.DebugLevel>
-        <avrgcc.assembler.debugging.DebugLevel>Default (-Wa,-g)</avrgcc.assembler.debugging.DebugLevel>
-      </AvrGcc>
+  <avrgcc.common.Device>-mmcu=avr128da48 -B "%24(PackRepoDir)\Atmel\AVR-Dx_DFP\2.7.321\gcc\dev\avr128da48"</avrgcc.common.Device>
+  <avrgcc.common.outputfiles.hex>True</avrgcc.common.outputfiles.hex>
+  <avrgcc.common.outputfiles.lss>True</avrgcc.common.outputfiles.lss>
+  <avrgcc.common.outputfiles.eep>True</avrgcc.common.outputfiles.eep>
+  <avrgcc.common.outputfiles.srec>False</avrgcc.common.outputfiles.srec>
+  <avrgcc.common.outputfiles.usersignatures>False</avrgcc.common.outputfiles.usersignatures>
+  <avrgcc.compiler.general.ChangeDefaultCharTypeUnsigned>True</avrgcc.compiler.general.ChangeDefaultCharTypeUnsigned>
+  <avrgcc.compiler.general.ChangeDefaultBitFieldUnsigned>True</avrgcc.compiler.general.ChangeDefaultBitFieldUnsigned>
+  <avrgcc.compiler.symbols.DefSymbols>
+    <ListValues>
+      <Value>F_CPU=24000000UL</Value>
+      <Value>LNPACKET_SIZE_MAX=6</Value>
+      <Value>LNPACKET_CNT=16</Value>
+      <Value>EXTXTAL</Value>
+      <Value>DEBUG</Value>
+      <Value>LNSTAT</Value>
+      <Value>ROUTE_DEBUG</Value>
+    </ListValues>
+  </avrgcc.compiler.symbols.DefSymbols>
+  <avrgcc.compiler.directories.IncludePaths>
+    <ListValues>
+      <Value>%24(ProjectDir)\lib\</Value>
+      <Value>%24(PackRepoDir)\Atmel\AVR-Dx_DFP\2.7.321\include\</Value>
+    </ListValues>
+  </avrgcc.compiler.directories.IncludePaths>
+  <avrgcc.compiler.optimization.level>Optimize debugging experience (-Og)</avrgcc.compiler.optimization.level>
+  <avrgcc.compiler.optimization.OtherFlags>-gdwarf-2</avrgcc.compiler.optimization.OtherFlags>
+  <avrgcc.compiler.optimization.PackStructureMembers>True</avrgcc.compiler.optimization.PackStructureMembers>
+  <avrgcc.compiler.optimization.AllocateBytesNeededForEnum>True</avrgcc.compiler.optimization.AllocateBytesNeededForEnum>
+  <avrgcc.compiler.optimization.DebugLevel>Default (-g2)</avrgcc.compiler.optimization.DebugLevel>
+  <avrgcc.compiler.warnings.AllWarnings>True</avrgcc.compiler.warnings.AllWarnings>
+  <avrgcc.compiler.warnings.WarningsAsErrors>True</avrgcc.compiler.warnings.WarningsAsErrors>
+  <avrgcc.linker.libraries.Libraries>
+    <ListValues>
+      <Value>libm</Value>
+    </ListValues>
+  </avrgcc.linker.libraries.Libraries>
+  <avrgcc.linker.miscellaneous.LinkerFlags>-T %24(ProjectDir)\routetables.ld -T %24(ProjectDir)\lib\avr-shell-cmd\cmdtables.ld</avrgcc.linker.miscellaneous.LinkerFlags>
+  <avrgcc.assembler.general.IncludePaths>
+    <ListValues>
+      <Value>%24(PackRepoDir)\Atmel\AVR-Dx_DFP\2.7.321\include\</Value>
+    </ListValues>
+  </avrgcc.assembler.general.IncludePaths>
+  <avrgcc.assembler.debugging.DebugLevel>Default (-Wa,-g)</avrgcc.assembler.debugging.DebugLevel>
+</AvrGcc>
     </ToolchainSettings>
   </PropertyGroup>
   <ItemGroup>

--- a/routectrl3/routetables.ld
+++ b/routectrl3/routetables.ld
@@ -9,11 +9,11 @@ SECTIONS
     *(.progmemx.data*)
     __progmemx_end = .;
     PROVIDE (__loconet_fbocctable_start = .) ;
-    *(SORT_BY_NAME(loconet.fbocctable*))
+    *(SORT_BY_INIT_PRIORITY(loconet.fbocctable*))
     PROVIDE (__loconet_fbocctable_end = .) ;
     KEEP(*(loconet.fbocctable*))
     PROVIDE (__loconet_fbfreetable_start = .) ;
-    *(SORT_BY_NAME(loconet.fbfreetable*))
+    *(SORT_BY_INIT_PRIORITY(loconet.fbfreetable*))
     PROVIDE (__loconet_fbfreetable_end = .) ;
     KEEP(*(loconet.fbfreetable*))
     PROVIDE (__loconet_fbrangeocctable_start = .) ;
@@ -25,7 +25,7 @@ SECTIONS
     PROVIDE (__loconet_fbrangefreetable_end = .) ;
     KEEP(*(loconet.fbrangefreetable))
     PROVIDE (__loconet_swreqtable_start = .) ;
-    *(SORT_BY_NAME(loconet.swreqtable*))
+    *(SORT_BY_INIT_PRIORITY(loconet.swreqtable*))
     PROVIDE (__loconet_swreqtable_end = .) ;
     KEEP(*(loconet.swreqtable*))
     PROVIDE (__loconet_swreqrangetable_start = .) ;
@@ -33,9 +33,9 @@ SECTIONS
     PROVIDE (__loconet_swreqrangetable_end = .) ;
     KEEP(*(loconet.swreqrangetable))
     PROVIDE (__loconet_routetable_start = .) ;
-    *(loconet.routetable)
+    *(SORT_BY_INIT_PRIORITY(loconet.routetable*))
     PROVIDE (__loconet_routetable_end = .) ;
-    KEEP(*(loconet.routetable))
+    KEEP(*(loconet.routetable*))
     . = ALIGN(2);
   }
 }


### PR DESCRIPTION
If using avr-gcc version 15 or newer, use __flashx instead of __memx for pointer to flash.
Use binary search for faster table lookup.